### PR TITLE
Leader -> Officer is a no.

### DIFF
--- a/src/FactionPower/FactionCommands.php
+++ b/src/FactionPower/FactionCommands.php
@@ -187,6 +187,10 @@ class FactionCommands {
 							$sender->sendMessage($this->plugin->formatMessage("§6- §cPlayer is already Officer"));
 							return true;
 						}
+						if($this->plugin->isLeader($args[1])) {
+							$sender->sendMessage($this->plugin->formatMessage("§6- §cThe target is the Leader, maybe it's you"));
+							return true;
+						}
                         if(!($this->plugin->getServer()->getPlayer($args[1]) instanceof Player)) {
 							$sender->sendMessage($this->plugin->formatMessage("§6- §cPlayer is offline!"));
                             return true;


### PR DESCRIPTION
This will prevent a Leader from playing /f promote (w/c I'm talking about myself lately) from promoting himself into an Officer and leave the faction leaderless.